### PR TITLE
Update pdfobject.js

### DIFF
--- a/pdfobject.js
+++ b/pdfobject.js
@@ -51,9 +51,9 @@ var PDFObject = function (obj){
     //Tests specifically for Adobe Reader (aka Acrobat) in Internet Explorer
     hasReaderActiveX = function (){
 
-        var axObj = null;
+        var axObj;
 
-        if (window.ActiveXObject) {
+        if (window.ActiveXObject || (window.hasOwnProperty && window.hasOwnProperty('ActiveXObject'))) {
 
             axObj = createAXO("AcroPDF.PDF");
 


### PR DESCRIPTION
if(window.ActiveXObject) would return false in IE 11, since window.ActiveXObject will return undefined.  However, the property is indeed there and using window.hasOwnProperty('ActiveXObject') will return true. The constructor call does work properly, even though IE 11 says it is undefined.
